### PR TITLE
🐛 fix hack.af link shortening

### DIFF
--- a/src/features/links.ts
+++ b/src/features/links.ts
@@ -11,9 +11,8 @@ const linking = async (app: App) => {
 		filterThreaded(false),
 		async ({ say, ...args }) => {
 			const message = args.message as GenericMessageEvent
-			const urlRegex =
-				/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi
-			const match = message.text?.match(urlRegex)?.[0]?.split('|')?.[0]
+			const urlRegex = "^(https|ftp|file)?://[^\s/$.?#].[^\s]*$"
+			const match = message.text?.match(urlRegex)?.[0]
 			if (match) {
 				const slug = async () => {
 					const tempSlug = nanoid(7)
@@ -57,9 +56,8 @@ const linking = async (app: App) => {
 	)
 
 	app.command('/shorten', async ({ ack, command, say }) => {
-		const urlRegex =
-			/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi
-		const match = command.text?.match(urlRegex)?.[0]?.split('|')?.[0]
+		const urlRegex = "^(https|ftp|file)?://[^\s/$.?#].[^\s]*$"
+		const match = command.text?.match(urlRegex)?.[0]
 		if (match) {
 			const slug = async () => {
 				const tempSlug = nanoid(7)

--- a/src/features/links.ts
+++ b/src/features/links.ts
@@ -12,7 +12,7 @@ const linking = async (app: App) => {
 		async ({ say, ...args }) => {
 			const message = args.message as GenericMessageEvent
 			const urlRegex = "^(https|ftp|file)?://[^\s/$.?#].[^\s]*$"
-			const match = message.text?.match(urlRegex)?.[0]
+			const match = message.text?.replace("<", "").replace(">","").split("|")?.[0].toLowerCase().match(urlRegex)
 			if (match) {
 				const slug = async () => {
 					const tempSlug = nanoid(7)
@@ -57,7 +57,7 @@ const linking = async (app: App) => {
 
 	app.command('/shorten', async ({ ack, command, say }) => {
 		const urlRegex = "^(https|ftp|file)?://[^\s/$.?#].[^\s]*$"
-		const match = command.text?.match(urlRegex)?.[0]
+		const match = command.text?.replace("<", "").replace(">","").split("|")?.[0].toLowerCase().match(urlRegex)
 		if (match) {
 			const slug = async () => {
 				const tempSlug = nanoid(7)


### PR DESCRIPTION
should fix link shortening by changing the regex. the existing regex didn't work when i tested it on a normal string, and the capitalization of the slack messages messed things up (**note: i am unable to get a dev environment working, so this was only tested with slack messages pulled from the api and NOT from a bot**).